### PR TITLE
Use "zpool status -P" instead of "zpool status"

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -208,6 +208,8 @@ Default value: present
 ##### `disk`
 
 The disk(s) for this pool. Can be an array or a space separated string.
+Use disk/device names as displayed by "zpool status". On Linux/ZOL, use 
+full device pathes as displayed by "zpool status -P". 
 
 ##### `mirror`
 

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
   def get_pool_data
     # https://docs.oracle.com/cd/E19082-01/817-2271/gbcve/index.html
     # we could also use zpool iostat -v mypool for a (little bit) cleaner output
-    out = execute("zpool status #{@resource[:pool]}", failonfail: false, combine: false)
+    out = execute("zpool status -P #{@resource[:pool]}", failonfail: false, combine: false)
     zpool_data = out.lines.select { |line| line.index("\t") == 0 }.map { |l| l.strip.split("\s")[0] }
     zpool_data.shift
     zpool_data

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -53,13 +53,13 @@ Puppet::Type.type(:zpool).provide(:zpool) do
     # https://docs.oracle.com/cd/E19082-01/817-2271/gbcve/index.html
     # we could also use zpool iostat -v mypool for a (little bit) cleaner output
     zpool_opts = case Facter.value(:kernel)
-      # use full device names ("-P") on Linux/ZOL to prevent
-      # mismatches between creation and display paths:
-      when 'Linux'
-        '-P'
-      else
-        ''
-      end
+                 # use full device names ("-P") on Linux/ZOL to prevent
+                 # mismatches between creation and display paths:
+                 when 'Linux'
+                   '-P'
+                 else
+                   ''
+                 end
     out = execute("zpool status #{zpool_opts} #{@resource[:pool]}", failonfail: false, combine: false)
     zpool_data = out.lines.select { |line| line.index("\t") == 0 }.map { |l| l.strip.split("\s")[0] }
     zpool_data.shift

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -52,7 +52,15 @@ Puppet::Type.type(:zpool).provide(:zpool) do
   def get_pool_data
     # https://docs.oracle.com/cd/E19082-01/817-2271/gbcve/index.html
     # we could also use zpool iostat -v mypool for a (little bit) cleaner output
-    out = execute("zpool status -P #{@resource[:pool]}", failonfail: false, combine: false)
+    zpool_opts = case Facter.value(:kernel)
+      # use full device names ("-P") on Linux/ZOL to prevent
+      # mismatches between creation and display paths:
+      when 'Linux'
+        '-P'
+      else
+        ''
+      end
+    out = execute("zpool status #{zpool_opts} #{@resource[:pool]}", failonfail: false, combine: false)
     zpool_data = out.lines.select { |line| line.index("\t") == 0 }.map { |l| l.strip.split("\s")[0] }
     zpool_data.shift
     zpool_data


### PR DESCRIPTION
This allows usage of e.g. LVs, LUKS-devices etc. with ZOL. Also currently only way (?) to use an L2ARC ("<dev> [...] cache <l2arc-dev>").

Otherwise result in errors like:
Error: zpool disk can't be changed. should be ["/dev/mapper/cryptdevice cache /dev/rootvg/l2arc"], currently is ["cryptdevice cache l2arc"]
(while the creation worked!)

Changing the devices to their short names ("cryptdevice" and "l2arc") will fix the above error, but fails to actually create the zpool (as there are no "/dev/cryptdevice" and "/dev/l2arc").

N.B.: this may actually break things on Solaris etc., if people use /dev-shortcuts there!