### PR TITLE
Add support for overlay option in zfs

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
 
   [:aclinherit, :atime, :canmount, :checksum,
    :compression, :copies, :dedup, :devices, :exec, :logbias,
-   :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
+   :mountpoint, :nbmand, :overlay, :primarycache, :quota, :readonly,
    :recordsize, :refquota, :refreservation, :reservation,
    :secondarycache, :setuid, :sharenfs, :sharesmb,
    :snapdir, :version, :volsize, :vscan, :xattr].each do |field|

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -76,6 +76,10 @@ module Puppet
       desc 'The nbmand property. Valid values are `on`, `off`.'
     end
 
+    newproperty(:overlay) do
+      desc 'The overlay property. Valid values are `on`, `off`.'
+    end
+
     newproperty(:primarycache) do
       desc 'The primarycache property. Valid values are `all`, `none`, `metadata`.'
     end

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
   describe 'zfs properties' do
     [:aclinherit, :aclmode, :atime, :canmount, :checksum,
      :compression, :copies, :dedup, :devices, :exec, :logbias,
-     :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
+     :mountpoint, :nbmand, :overlay, :primarycache, :quota, :readonly,
      :recordsize, :refquota, :refreservation, :reservation,
      :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb,
      :snapdir, :version, :volsize, :vscan, :xattr].each do |prop|

--- a/spec/unit/type/zfs_spec.rb
+++ b/spec/unit/type/zfs_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:zfs) do
-  properties = [:ensure, :mountpoint, :compression, :copies, :quota, :reservation, :sharenfs, :snapdir]
+  properties = [:ensure, :mountpoint, :compression, :copies, :overlay, :quota, :reservation, :sharenfs, :snapdir]
 
   properties.each do |property|
     it "should have a #{property} property" do


### PR DESCRIPTION
(MODULES-8823) Add `overlay` option for resource `zfs`

As described in the ticket (https://tickets.puppetlabs.com/browse/MODULES-8823) this option allows mounting over non empty directories. The current master of `zfs_core` simply doesn't implement such option on the `zfs` resource. This change allows for specification of such option in puppet modules:

```
zfs { 'my_pool/my_volume':
    ensure      => present,
    mountpoint  => '/mnt/non_empty_dir',
    overlay     => 'on'
}
```
