### PR TITLE
Revert "(MODULES-8823) Add support for overlay option in zfs"

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
 
   [:aclinherit, :atime, :canmount, :checksum,
    :compression, :copies, :dedup, :devices, :exec, :logbias,
-   :mountpoint, :nbmand, :overlay, :primarycache, :quota, :readonly,
+   :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
    :recordsize, :refquota, :refreservation, :reservation,
    :secondarycache, :setuid, :sharenfs, :sharesmb,
    :snapdir, :version, :volsize, :vscan, :xattr].each do |field|

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -76,10 +76,6 @@ module Puppet
       desc 'The nbmand property. Valid values are `on`, `off`.'
     end
 
-    newproperty(:overlay) do
-      desc 'The overlay property. Valid values are `on`, `off`.'
-    end
-
     newproperty(:primarycache) do
       desc 'The primarycache property. Valid values are `all`, `none`, `metadata`.'
     end

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
   describe 'zfs properties' do
     [:aclinherit, :aclmode, :atime, :canmount, :checksum,
      :compression, :copies, :dedup, :devices, :exec, :logbias,
-     :mountpoint, :nbmand, :overlay, :primarycache, :quota, :readonly,
+     :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
      :recordsize, :refquota, :refreservation, :reservation,
      :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb,
      :snapdir, :version, :volsize, :vscan, :xattr].each do |prop|

--- a/spec/unit/type/zfs_spec.rb
+++ b/spec/unit/type/zfs_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:zfs) do
-  properties = [:ensure, :mountpoint, :compression, :copies, :overlay, :quota, :reservation, :sharenfs, :snapdir]
+  properties = [:ensure, :mountpoint, :compression, :copies, :quota, :reservation, :sharenfs, :snapdir]
 
   properties.each do |property|
     it "should have a #{property} property" do


### PR DESCRIPTION
This reverts commit 4e1d055ece08b3fb497ea593172a38ad74d71b6f.

zfs on Solaris does not support `overlay` causing our tests to fail:

Reverting this PR.
{code}
07:03:19         puppet resource zfs tstpool/tstfs
07:03:19        Last 10 lines of output were:
07:03:19        	Error: Could not run: Execution of '/usr/sbin/zfs get -H -o value overlay tstpool/tstfs' returned 2: bad property list: invalid property 'overlay'
07:03:19        	For more info, run: zfs help get
{code}