### PR TITLE
(MODULES-8823) Better handling of ZFS overlay property on Linux

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   # aclmode was removed from S11 in build 139 but it may have been added back
   # acltype is for ZFS on Linux, and allows disabling or enabling POSIX ACLs
   # http://webcache.googleusercontent.com/search?q=cache:-p74K0DVsdwJ:developers.slashdot.org/story/11/11/09/2343258/solaris-11-released+&cd=13
-  [:aclmode, :acltype, :shareiscsi].each do |field|
+  [:aclmode, :acltype, :shareiscsi, :overlay].each do |field|
     # The zfs commands use the property value '-' to indicate that the
     # property is not set. We make use of this value to indicate that the
     # property is not set since it is not available. Conversely, if these
@@ -79,17 +79,12 @@ Puppet::Type.type(:zfs).provide(:zfs) do
     end
   end
 
-  zfs_properties = [:aclinherit, :atime, :canmount, :checksum,
-                    :compression, :copies, :dedup, :devices, :exec, :logbias,
-                    :mountpoint, :nbmand, :primarycache, :quota, :readonly,
-                    :recordsize, :refquota, :refreservation, :reservation,
-                    :secondarycache, :setuid, :sharenfs, :sharesmb,
-                    :snapdir, :version, :volsize, :vscan, :xattr]
-
-  # The overlay property is only supported on Linux
-  zfs_properties << :overlay if Facter.value(:kernel) == 'Linux'
-
-  zfs_properties.each do |field|
+  [:aclinherit, :atime, :canmount, :checksum,
+   :compression, :copies, :dedup, :devices, :exec, :logbias,
+   :mountpoint, :nbmand, :primarycache, :quota, :readonly,
+   :recordsize, :refquota, :refreservation, :reservation,
+   :secondarycache, :setuid, :sharenfs, :sharesmb,
+   :snapdir, :version, :volsize, :vscan, :xattr].each do |field|
     define_method(field) do
       zfs(:get, '-H', '-o', 'value', field, @resource[:name]).strip
     end

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -76,9 +76,11 @@ module Puppet
       desc 'The nbmand property. Valid values are `on`, `off`.'
     end
 
-    if Facter.value(:kernel) == 'Linux'
-      newproperty(:overlay) do
-        desc 'The overlay property. Valid values are `on`, `off`.'
+    newproperty(:overlay) do
+      desc 'The overlay property. Valid values are `on`, `off`.'
+
+      validate do |_value|
+        raise Puppet::Error _('This property is only supported on Linux') unless Facter.value(:kernel) == 'Linux'
       end
     end
 


### PR DESCRIPTION
The zfs commands use the property value '-' to indicate that the property is not set.

We make use of this value to indicate that the `overlay` property is not set since it is not available.

The implementation added by #22 did not cover cases where the puppetserver ran on non-Linux platforms. This fixes that issue.

Passing ad-hoc: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/modules/view/Core/view/zfs_core/view/adhoc/job/forge-module_puppetlabs-zfs_core_intn-sys_nightly-adhoc/6/