### PR TITLE
(maint) fix resource assert alignment

### DIFF
--- a/spec/acceptance/tests/zpool/basic_tests_spec.rb
+++ b/spec/acceptance/tests/zpool/basic_tests_spec.rb
@@ -46,7 +46,7 @@ RSpec.context 'ZPool: Basic Tests' do
 
       # ZPool: verify puppet resource reports on the disk array
       on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure => 'present'}, @result.stdout, "err: #{agent}")
+        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
         assert_match(%r{disk +=> .'.+dsk1 .+dsk2'.}, @result.stdout, "err: #{agent}")
       end
 
@@ -75,8 +75,8 @@ RSpec.context 'ZPool: Basic Tests' do
 
       # ZPool: verify puppet resource reports on the mirror
       on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure => 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{mirror => \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, @result.stdout, "err: #{agent}")
+        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
+        assert_match(%r{mirror\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, @result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for multiple mirrors
@@ -106,8 +106,8 @@ RSpec.context 'ZPool: Basic Tests' do
 
       # ZPool: verify puppet resource reports on both mirrors
       on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure => 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{mirror => \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, @result.stdout, "err: #{agent}")
+        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
+        assert_match(%r{mirror\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, @result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for raidz test
@@ -135,8 +135,8 @@ RSpec.context 'ZPool: Basic Tests' do
 
       # ZPool: verify puppet reports on the raidz pool
       on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure => 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{raidz  => \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, @result.stdout, "err: #{agent}")
+        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
+        assert_match(%r{raidz\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, @result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for multiple raidz pools
@@ -166,8 +166,8 @@ RSpec.context 'ZPool: Basic Tests' do
 
       # ZPool: verify puppet resource reports on both raidz
       on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure => 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{raidz  => \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, @result.stdout, "err: #{agent}")
+        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
+        assert_match(%r{raidz\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, @result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove


### PR DESCRIPTION
due to this: https://tickets.puppetlabs.com/browse/PUP-3721 the output of puppet resources has changed causing some of the tests to fail.
This PR updates the assertions.
