### PR TITLE
(MODULES-10592) Fix `zpool status` parsing on Linux

### DIFF
--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -34,7 +34,12 @@ Puppet::Type.type(:zpool).provide(:zpool) do
         sym = (value =~ %r{^mirror}) ? :mirror : :raidz
         pool[:raid_parity] = 'raidz2' if value =~ %r{^raidz2}
       else
-        tmp << value
+        # get full drive name if the value is a partition (Linux only)
+        tmp << if Facter.value(:kernel) == 'Linux' && value =~ %r{/dev/(:?[a-z]+1|disk/by-id/.+-part1)$}
+                 execute("lsblk -p -no pkname #{value}").chomp
+               else
+                 value
+               end
         sym = :disk if value == pool_array.first
       end
 

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -12,6 +12,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
 
   before(:each) do
     allow(provider.class).to receive(:which).with('zfs') { zfs }
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
   end
 
   context '.instances' do

--- a/spec/unit/provider/zpool/zpool_spec.rb
+++ b/spec/unit/provider/zpool/zpool_spec.rb
@@ -12,6 +12,7 @@ describe Puppet::Type.type(:zpool).provider(:zpool) do
 
   before(:each) do
     allow(provider.class).to receive(:which).with('zpool') { zpool }
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
   end
 
   context '#current_pool' do
@@ -56,6 +57,15 @@ describe Puppet::Type.type(:zpool).provider(:zpool) do
     describe 'when there is no data' do
       it 'returns a hash with ensure=>:absent' do
         expect(provider.process_zpool_data([])[:ensure]).to eq(:absent)
+      end
+    end
+
+    describe 'when there are full path disks on Linux' do
+      it 'munges partitions into disk names' do
+        allow(provider).to receive(:execute).with('lsblk -p -no pkname /dev/sdc1').and_return('/dev/sdc')
+        allow(provider).to receive(:execute).with('lsblk -p -no pkname /dev/disk/by-id/disk_serial-0:0-part1').and_return('/dev/disk/by-id/disk_serial-0:0')
+        zpool_data = ['foo', '/dev/sdc1', '/dev/disk/by-id/disk_serial-0:0-part1']
+        expect(provider.process_zpool_data(zpool_data)[:disk]).to eq(['/dev/sdc /dev/disk/by-id/disk_serial-0:0'])
       end
     end
 


### PR DESCRIPTION
Since #14 was merged, `zpool status` output shows full paths for disks. This causes partitions to show up instead of disk devices, e.g. `/dev/sda1` for `sda`.

This would cause idempotency issues when managing zpools, due to zfs partitioning the drive:

```sh-session
> puppet resource zpool tstpool disk=/dev/sda ensure=present
Notice: /Zpool[tstpool]/ensure: created
zpool { 'tstpool':
  ensure   => 'present',
  disk     => ['/dev/sda1'],
  provider => 'zpool',
}

> puppet resource zpool tstpool disk=/dev/sda ensure=present
Error: zpool disk can't be changed. should be ["/dev/sda"], currently is ["/dev/sda1"]
Error: /Zpool[tstpool]/disk: change from ['/dev/sda1'] to ['/dev/sda'] failed: zpool disk can't be changed. should be ["/dev/sda"], currently is ["/dev/sda1"]

> zpool status -P tstpool
  pool: tstpool
 state: ONLINE
  scan: none requested
config:

	NAME         STATE     READ WRITE CKSUM
	tstpool      ONLINE       0     0     0
	  /dev/sda1  ONLINE       0     0     0

errors: No known data errors
```
This commit removes the partition numbers when parsing `zpool status` output by running `lsblk` on the full path to find out the disk name.