### PR TITLE
(MODULES-10726) Add support for ashift/autoexpand/failmode to the zpool provider.

### DIFF
--- a/lib/puppet/type/zpool.rb
+++ b/lib/puppet/type/zpool.rb
@@ -90,6 +90,22 @@ module Puppet
       desc 'Log disks for this pool. This type does not currently support mirroring of log disks.'
     end
 
+    newproperty(:ashift) do
+      desc 'The Alignment Shift for the vdevs in the given pool.'
+
+      validate do |_value|
+        raise Puppet::Error _('This property is only supported on Linux') unless Facter.value(:kernel) == 'Linux'
+      end
+    end
+
+    newproperty(:autoexpand) do
+      desc 'The autoexpand setting for the given pool. Valid values are `on` or `off`'
+    end
+
+    newproperty(:failmode) do
+      desc 'The failmode setting for the given pool. Valid values are `wait`, `continue` or `panic`'
+    end
+
     newparam(:pool) do
       desc 'The name for this pool.'
       isnamevar

--- a/spec/unit/type/zpool_spec.rb
+++ b/spec/unit/type/zpool_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'zpool' do
   describe Puppet::Type.type(:zpool) do
-    properties = [:ensure, :disk, :mirror, :raidz, :spare, :log]
+    properties = [:ensure, :disk, :mirror, :raidz, :spare, :log, :autoexpand, :failmode, :ashift]
     properties.each do |property|
       it "should have a #{property} property" do
         expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)


### PR DESCRIPTION
This PR adds support for setting ashift (linux only), autoexpand, and failmode on zpools, 

Both setting them individually, and also as part of creation
ashift (Only valid on linux)
autoexpand
failmode.