### PR TITLE
(MODULES-10730) Clear duplicate constant warning when doing puppet run

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
     end
   end
 
-  PARAMETER_UNSET_OR_NOT_AVAILABLE = '-'.freeze
+  PARAMETER_UNSET_OR_NOT_AVAILABLE = '-'.freeze unless defined? PARAMETER_UNSET_OR_NOT_AVAILABLE
 
   # https://docs.oracle.com/cd/E19963-01/html/821-1448/gbscy.html
   # shareiscsi (added in build 120) was removed from S11 build 136


### PR DESCRIPTION
It looks like my previous PR causes a duplicate constant warning when defining both a pool and filesystem as the constant is already defined there.

I've chosen to add an unless? to the constant in zfs.rb, so that if it's already defined, it doesn't try to redefine it again.