### PR TITLE
WIP: (MODULES-10732) Resolve symlinks then compare 

### DIFF
--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
         sym = (value =~ %r{^mirror}) ? :mirror : :raidz
         pool[:raid_parity] = 'raidz2' if value =~ %r{^raidz2}
       else
-        vdev = if File.symlink?(value) and File.readlink(value) !~ %r{dm-[0-9]+$}
+        vdev = if Facter.value(:kernel) == 'Linux' && File.symlink?(value) && File.readlink(value) !~ %r{dm-[0-9]+$}
                  File.expand_path(File.readlink(value), File.dirname(value))
                else
                  value

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
         sym = (value =~ %r{^mirror}) ? :mirror : :raidz
         pool[:raid_parity] = 'raidz2' if value =~ %r{^raidz2}
       else
-        vdev = if Facter.value(:kernel) == 'Linux' && File.symlink?(value)
+        vdev = if File.symlink?(value) and File.readlink(value) !~ %r{dm-[0-9]+$}
                  File.expand_path(File.readlink(value), File.dirname(value))
                else
                  value


### PR DESCRIPTION
This is a draft currently, on CentOS 6 lsblk doesn't support -p, so this results in an error when converting devices.

This is one option, but not sure if this is the way we want to fix this, or even if we should given CentOS 6 goes out of support in November.