### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,52 +12,13 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
-    },
-    {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent
platform, it should be enough to specify the supported OS, without
specific versions. It is assumed that for each OS in metadata.json, the
versions supported are the same as what the agent itself supports.

Note: Puppet does not 'oficially' support ZFS on Linux (meaning we do
not test against Linux configurations and we don't commit to solve and
issues related to ZoL), so remove Linux platforms from metadata.json.
However, we happily accept community contributions that do not break any
Solaris functionality.