### PR TITLE
(maint) Follow up PDK updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"settings": {
 		"terminal.integrated.profiles.linux": {
 			"bash": {
-				"path": "bash",
+				"path": "bash"
 			}
 		}
 	},

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -34,7 +34,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.rspec

--- a/.sync.yml
+++ b/.sync.yml
@@ -21,6 +21,7 @@ Gemfile:
         from_env: BEAKER_PUPPET_VERSION
         version: '~> 1.22'
       - gem: github_changelog_generator
+        version: '=1.15.2'
       # We can unpin async when we move to Ruby 3
       - gem: async
         version: '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 group :system_tests do
   gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]
   gem "serverspec", '~> 2.41',    require: false
+  gem "voxpupuli-acceptance"
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
+require 'voxpupuli/acceptance/rake'
 
 def changelog_user
   return unless Rake.application.top_level_tasks.include? "changelog"

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,6 @@
     }
   ],
   "pdk-version": "2.6.1",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#2.7.1",
-  "template-ref": "tags/2.7.1-0-g9a16c87"
+  "template-url": "https://github.com/puppetlabs/pdk-templates#main",
+  "template-ref": "heads/main-0-g0bbd7f1"
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,7 @@
 require 'beaker-rspec'
 require 'beaker/module_install_helper'
 require 'beaker/puppet_install_helper'
+require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 $LOAD_PATH << File.join(__dir__, 'acceptance/lib')
 require 'solaris_util'


### PR DESCRIPTION
This PR:

- Adds the voxpupuli-acceptance gem, which should re-add the Beaker rake task that was inadvertently removed in https://github.com/puppetlabs/puppetlabs-zfs_core/commit/b72a0c83b7d333426e8552b4ce472bc586d9ec53 .
- Updates the PDK template to the latest, unreleased version to pull in a new container image to fix the auto release GitHub Action.
- Pins the github_changelog_generator gem, as newer versions cause issues.
- Adds .rspec to .gitignore.