### PR TITLE
(maint) Fix auto release action

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -33,10 +33,12 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    # We use the dev tools image here because the PDK image does not have the
+    # build tools necessary to compile native extensions.
     - name: "PDK Release prep"
-      uses: docker://puppet/pdk:2.6.1.0
+      uses: docker://puppet/puppet-dev-tools:4.x
       with:
-        args: 'release prep --force'
+        args: 'pdk release prep --force --debug'
       env:
         CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.sync.yml
+++ b/.sync.yml
@@ -21,7 +21,9 @@ Gemfile:
         from_env: BEAKER_PUPPET_VERSION
         version: '~> 1.22'
       - gem: github_changelog_generator
-        version: '=1.15.2'
+        version: '= 1.16.4'
+      - gem: concurrent-ruby
+        version: '= 1.1.10'
       # We can unpin async when we move to Ruby 3
       - gem: async
         version: '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ group :development do
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
-  gem "github_changelog_generator",                                             require: false
+  gem "github_changelog_generator", '= 1.16.4',                                 require: false
+  gem "concurrent-ruby", '= 1.1.10',                                            require: false
   gem "async", '~> 1',                                                          require: false
   gem "beaker-module_install_helper",                                           require: false
   gem "beaker-puppet_install_helper",                                           require: false


### PR DESCRIPTION
The Auto Release GitHub Action does not currently work for this repository.

This PR makes updates to the Docker image that Auto Release uses to bring in the build tools necessary to compile native extensions for gems we rely on.

It also pins the github_changelog_generator and concurrent-ruby gems.

This is based off learnings from the Support team: https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector/pull/186