### PR TITLE
Update deprecated Beaker methods

### DIFF
--- a/spec/acceptance/tests/zfs/basic_tests_spec.rb
+++ b/spec/acceptance/tests/zfs/basic_tests_spec.rb
@@ -30,7 +30,7 @@ RSpec.context 'ZFS: Basic Tests' do
 
       # ZFS: idempotence - create
       apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        assert_no_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
       end
 
       # ZFS: cleanup for next test

--- a/spec/acceptance/tests/zfs/basic_tests_spec.rb
+++ b/spec/acceptance/tests/zfs/basic_tests_spec.rb
@@ -24,35 +24,35 @@ RSpec.context 'ZFS: Basic Tests' do
   solaris_agents.each do |agent|
     it 'can create and clean up an idempotent resource' do
       # ZFS: basic - ensure it is created
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: idempotence - create
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do |result|
+        refute_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: cleanup for next test
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>absent}') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>absent}') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
 
     it 'can create and clean up a resource with a mount point' do
       # ZFS: create with a mount point
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt"}') do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt"}') do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: change mount point and verify
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do
-        assert_match(%r{mountpoint changed '.ztstpool.mnt'.* to '.ztstpool.mnt2'}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do |result|
+        assert_match(%r{mountpoint changed '.ztstpool.mnt'.* to '.ztstpool.mnt2'}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: ensure can be removed
-      apply_manifest_on(agent, 'zfs { "tstpool/tstfs": ensure=>absent}') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs { "tstpool/tstfs": ensure=>absent}') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zfs/should_be_idempotent_spec.rb
+++ b/spec/acceptance/tests/zfs/should_be_idempotent_spec.rb
@@ -18,23 +18,23 @@ RSpec.context 'ZFS: Should be Idempotent' do
   solaris_agents.each do |agent|
     it 'creates and updates a resource in an idempotent way' do
       # ZFS: create with a mount point
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt"}') do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt"}') do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: idempotence - create
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do |result|
+        refute_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: change mount point and verify
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do
-        assert_match(%r{mountpoint changed '.ztstpool.mnt'.* to '.ztstpool.mnt2'}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do |result|
+        assert_match(%r{mountpoint changed '.ztstpool.mnt'.* to '.ztstpool.mnt2'}, result.stdout, "err: #{agent}")
       end
 
       # ZFS: change mount point and verify idempotence
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do
-        refute_match(%r{changed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do |result|
+        refute_match(%r{changed}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zfs/should_be_idempotent_spec.rb
+++ b/spec/acceptance/tests/zfs/should_be_idempotent_spec.rb
@@ -24,7 +24,7 @@ RSpec.context 'ZFS: Should be Idempotent' do
 
       # ZFS: idempotence - create
       apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        assert_no_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
       end
 
       # ZFS: change mount point and verify
@@ -34,7 +34,7 @@ RSpec.context 'ZFS: Should be Idempotent' do
 
       # ZFS: change mount point and verify idempotence
       apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present,  mountpoint=>"/ztstpool/mnt2"}') do
-        assert_no_match(%r{changed}, @result.stdout, "err: #{agent}")
+        refute_match(%r{changed}, @result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zfs/should_create_spec.rb
+++ b/spec/acceptance/tests/zfs/should_create_spec.rb
@@ -18,13 +18,13 @@ RSpec.context 'ZFS: Should Create' do
   solaris_agents.each do |agent|
     it 'creates a zfs resource' do
       # ZFS: ensure it is created
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # verify
-      on(agent, 'zfs list') do
-        assert_match(%r{tstpool.tstfs}, @result.stdout, "err: #{agent}")
+      on(agent, 'zfs list') do |result|
+        assert_match(%r{tstpool.tstfs}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zfs/should_query_spec.rb
+++ b/spec/acceptance/tests/zfs/should_query_spec.rb
@@ -18,18 +18,18 @@ RSpec.context 'ZFS: Should Query' do
   solaris_agents.each do |agent|
     it 'can query and report both managed and unmanaged resources' do
       # ZFS: basic - ensure it is created
-      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs {"tstpool/tstfs": ensure=>present}') do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # query one.
-      on(agent, 'puppet resource zfs tstpool/tstfs') do
-        assert_match(%r{ensure *=> *'present'}, @result.stdout, "err: #{agent}")
+      on(agent, 'puppet resource zfs tstpool/tstfs') do |result|
+        assert_match(%r{ensure *=> *'present'}, result.stdout, "err: #{agent}")
       end
 
       # query all.
-      on(agent, 'puppet resource zfs') do
-        assert_match(%r{tstpool.tstfs}, @result.stdout, "err: #{agent}")
+      on(agent, 'puppet resource zfs') do |result|
+        assert_match(%r{tstpool.tstfs}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zfs/should_remove_spec.rb
+++ b/spec/acceptance/tests/zfs/should_remove_spec.rb
@@ -18,11 +18,11 @@ RSpec.context 'ZFS: Should Remove' do
   solaris_agents.each do |agent|
     it 'can remove resources' do
       # ZFS: create
-      on agent, 'zfs create tstpool/tstfs'
+      on(agent, 'zfs create tstpool/tstfs')
 
       # ZFS: ensure can be removed.
-      apply_manifest_on(agent, 'zfs { "tstpool/tstfs": ensure=>absent}') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zfs { "tstpool/tstfs": ensure=>absent}') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/basic_tests_spec.rb
+++ b/spec/acceptance/tests/zpool/basic_tests_spec.rb
@@ -18,81 +18,81 @@ RSpec.context 'ZPool: Basic Tests' do
   solaris_agents.each do |agent|
     it 'can create an idempotent zpool resource' do
       # ZPool: create zpool disk
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: zpool should be idempotent
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do |result|
+        refute_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool
-      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
 
     it 'can create a zpool resource with a disk array' do
       # ZPool: create zpool with a disk array
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>['/ztstpool/dsk1','/ztstpool/dsk2'] }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>['/ztstpool/dsk1','/ztstpool/dsk2'] }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify disk array was created
-      on agent, 'zpool list -H' do
-        assert_match(%r{tstpool}, @result.stdout, "err: #{agent}")
+      on(agent, 'zpool list -H') do |result|
+        assert_match(%r{tstpool}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify puppet resource reports on the disk array
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{disk +=> .'.+dsk1 .+dsk2'.}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{ensure\s+=> 'present'}, result.stdout, "err: #{agent}")
+        assert_match(%r{disk +=> .'.+dsk1 .+dsk2'.}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for mirror tests
-      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
 
     it 'can create a mirrored zpool resource with 3 virtual devices' do
       # ZPool: create mirrored zpool with 3 virtual devices
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, mirror=>['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'] }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, mirror=>['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'] }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify mirrors were created
-      on agent, 'zpool status -v tstpool' do
+      on(agent, 'zpool status -v tstpool') do |result|
         # 	NAME                STATE     READ WRITE CKSUM
         # tstpool             ONLINE       0     0     0
         #   mirror-0          ONLINE       0     0     0
         #     /ztstpool/dsk1  ONLINE       0     0     0
         #     /ztstpool/dsk2  ONLINE       0     0     0
         #     /ztstpool/dsk3  ONLINE       0     0     0
-        assert_match(%r{tstpool.*\n\s+mirror.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s*/ztstpool/dsk3}m, @result.stdout, "err: #{agent}")
+        assert_match(%r{tstpool.*\n\s+mirror.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s*/ztstpool/dsk3}m, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify puppet resource reports on the mirror
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{mirror\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{ensure\s+=> 'present'}, result.stdout, "err: #{agent}")
+        assert_match(%r{mirror\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for multiple mirrors
-      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
 
     it 'can create two mirrored zpools each with two virtual devices' do
       # ZPool: create 2 mirrored zpools each with 2 virtual devices
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, mirror=>['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'] }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, mirror=>['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'] }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify both mirrors were created
-      on agent, 'zpool status -v tstpool' do
+      on(agent, 'zpool status -v tstpool') do |result|
         # 	NAME                STATE     READ WRITE CKSUM
         # tstpool             ONLINE       0     0     0
         #   mirror-0          ONLINE       0     0     0
@@ -101,58 +101,64 @@ RSpec.context 'ZPool: Basic Tests' do
         #   mirror-1          ONLINE       0     0     0
         #     /ztstpool/dsk3  ONLINE       0     0     0
         #     /ztstpool/dsk5  ONLINE       0     0     0
-        assert_match(%r{tstpool.*\n\s+mirror.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s+mirror.*\n\s*/ztstpool\/dsk3.*\n\s*/ztstpool/dsk5}m, @result.stdout, "err: #{agent}")
+        assert_match(%r{tstpool.*\n\s+mirror.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s+mirror.*\n\s*/ztstpool\/dsk3.*\n\s*/ztstpool/dsk5}m, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify puppet resource reports on both mirrors
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{mirror\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{ensure\s+=> 'present'}, result.stdout, "err: #{agent}")
+        assert_match(%r{mirror\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for raidz test
-      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
 
     it 'can create raidz pool consisting of three virtual devices' do
       # ZPool: create raidz pool consisting of 3 virtual devices
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, raidz=>['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'] }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, raidz=>['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'] }") do |result|
+        pp "THIS IS THE RESULT: #{result} THIS IS THE RESULT'S CLASS #{result.class}"
+        pp "THIS IS THE RESULT METHODS #{result.methods.sort}"
+        pp "RESULT.STDOUT IS #{result.stdout} RESULT.STDERR IS #{result.stderr}"
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify raidz pool was created
-      on agent, 'zpool status -v tstpool' do
+      on(agent, 'zpool status -v tstpool') do |result|
         # 	NAME                STATE     READ WRITE CKSUM
         # tstpool             ONLINE       0     0     0
         #   raidz1-0          ONLINE       0     0     0
         #     /ztstpool/dsk1  ONLINE       0     0     0
         #     /ztstpool/dsk2  ONLINE       0     0     0
         #     /ztstpool/dsk3  ONLINE       0     0     0
-        assert_match(%r{tstpool.*\n\s+raidz.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s*/ztstpool/dsk3}m, @result.stdout, "err: #{agent}")
+        assert_match(%r{tstpool.*\n\s+raidz.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s*/ztstpool/dsk3}m, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify puppet reports on the raidz pool
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{raidz\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{ensure\s+=> 'present'}, result.stdout, "err: #{agent}")
+        assert_match(%r{raidz\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2 /ztstpool/dsk3'\]}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool in preparation for multiple raidz pools
-      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
     end
 
     it 'can create two raidz zpools each with two virtual devices' do
       # ZPool: create 2 mirrored zpools each with 2 virtual devices
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, raidz=>['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'] }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, raidz=>['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'] }") do |result|
+        pp "THIS IS THE RESULT: #{result} THIS IS THE RESULT'S CLASS #{result.class}"
+        pp "THIS IS THE RESULT METHODS #{result.methods.sort}"
+        pp "RESULT.STDOUT IS #{result.stdout} RESULT.STDERR IS #{result.stderr}"
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify both raidz were created
-      on agent, 'zpool status -v tstpool' do
+      on(agent, 'zpool status -v tstpool') do |result|
         # 	NAME                STATE     READ WRITE CKSUM
         # tstpool             ONLINE       0     0     0
         #   raidz1-0          ONLINE       0     0     0
@@ -161,18 +167,18 @@ RSpec.context 'ZPool: Basic Tests' do
         #   raidz1-1          ONLINE       0     0     0
         #     /ztstpool/dsk3  ONLINE       0     0     0
         #     /ztstpool/dsk5  ONLINE       0     0     0
-        assert_match(%r{tstpool.*\n\s+raidz.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s+raidz.*\n\s*/ztstpool/dsk3.*\n\s*/ztstpool/dsk5}m, @result.stdout, "err: #{agent}")
+        assert_match(%r{tstpool.*\n\s+raidz.*\n\s*/ztstpool/dsk1.*\n\s*/ztstpool/dsk2.*\n\s+raidz.*\n\s*/ztstpool/dsk3.*\n\s*/ztstpool/dsk5}m, result.stdout, "err: #{agent}")
       end
 
       # ZPool: verify puppet resource reports on both raidz
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure\s+=> 'present'}, @result.stdout, "err: #{agent}")
-        assert_match(%r{raidz\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{ensure\s+=> 'present'}, result.stdout, "err: #{agent}")
+        assert_match(%r{raidz\s+=> \['/ztstpool/dsk1 /ztstpool/dsk2', '/ztstpool/dsk3 /ztstpool/dsk5'\]}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove
-      apply_manifest_on(agent, 'zpool { tstpool: ensure => absent }') do
-        assert_match(%(ensure: removed), @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool { tstpool: ensure => absent }') do |result|
+        assert_match(%(ensure: removed), result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/basic_tests_spec.rb
+++ b/spec/acceptance/tests/zpool/basic_tests_spec.rb
@@ -24,7 +24,7 @@ RSpec.context 'ZPool: Basic Tests' do
 
       # ZPool: zpool should be idempotent
       apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        assert_no_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove zpool

--- a/spec/acceptance/tests/zpool/should_be_idempotent_spec.rb
+++ b/spec/acceptance/tests/zpool/should_be_idempotent_spec.rb
@@ -24,7 +24,7 @@ RSpec.context 'ZPool: Should be Idempotent' do
 
       # ZPool: idempotency - create
       apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        assert_no_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/should_be_idempotent_spec.rb
+++ b/spec/acceptance/tests/zpool/should_be_idempotent_spec.rb
@@ -18,13 +18,13 @@ RSpec.context 'ZPool: Should be Idempotent' do
   solaris_agents.each do |agent|
     it 'creates an idempotent resource' do
       # ZPool: ensure create
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: idempotency - create
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        refute_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do |result|
+        refute_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/should_create_spec.rb
+++ b/spec/acceptance/tests/zpool/should_create_spec.rb
@@ -18,12 +18,12 @@ RSpec.context 'ZPool: Should Create' do
   solaris_agents.each do |agent|
     it 'creates a zpool resource' do
       # ZPool: ensure create
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
-      on(agent, 'zpool list') do
-        assert_match(%r{tstpool}, @result.stdout, "err: #{agent}")
+      on(agent, 'zpool list') do |result|
+        assert_match(%r{tstpool}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/should_query_spec.rb
+++ b/spec/acceptance/tests/zpool/should_query_spec.rb
@@ -18,18 +18,18 @@ RSpec.context 'ZPool: Should Query' do
   solaris_agents.each do |agent|
     it 'queries both manages and unmanages zpool resources' do
       # ZPool: ensure create
-      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do
-        assert_match(%r{ensure: created}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, "zpool{ tstpool: ensure=>present, disk=>'/ztstpool/dsk1' }") do |result|
+        assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: query one
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{ensure *=> *'present'}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{ensure *=> *'present'}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: query all
-      on(agent, puppet('resource zpool tstpool')) do
-        assert_match(%r{tstpool'}, @result.stdout, "err: #{agent}")
+      on(agent, puppet('resource zpool tstpool')) do |result|
+        assert_match(%r{tstpool'}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/should_remove_spec.rb
+++ b/spec/acceptance/tests/zpool/should_remove_spec.rb
@@ -19,16 +19,16 @@ RSpec.context 'ZPool: Should Remove' do
     it 'removes a specified resource' do
       # ZPool: create
       on(agent, 'zpool create tstpool /ztstpool/dsk1')
-      on(agent, 'zpool list') do
-        assert_match(%r{tstpool}, @result.stdout, "err: #{agent}")
+      on(agent, 'zpool list') do |result|
+        assert_match(%r{tstpool}, result.stdout, "err: #{agent}")
       end
 
       # ZPool: remove
-      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do
-        assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
+      apply_manifest_on(agent, 'zpool{ tstpool: ensure=>absent }') do |result|
+        assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
       end
-      on(agent, 'zpool list') do
-        refute_match(%r{tstpool}, @result.stdout, "err: #{agent}")
+      on(agent, 'zpool list') do |result|
+        refute_match(%r{tstpool}, result.stdout, "err: #{agent}")
       end
     end
   end

--- a/spec/acceptance/tests/zpool/should_remove_spec.rb
+++ b/spec/acceptance/tests/zpool/should_remove_spec.rb
@@ -28,7 +28,7 @@ RSpec.context 'ZPool: Should Remove' do
         assert_match(%r{ensure: removed}, @result.stdout, "err: #{agent}")
       end
       on(agent, 'zpool list') do
-        assert_no_match(%r{tstpool}, @result.stdout, "err: #{agent}")
+        refute_match(%r{tstpool}, @result.stdout, "err: #{agent}")
       end
     end
   end


### PR DESCRIPTION
This PR updates several deprecated Beaker methods that were removed entirely in Beaker 5. This is in preparation for moving to Beaker 5 for tests.