### PR TITLE
zfs_specs: fix typo in "jailed"

### DIFF
--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -119,7 +119,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
         expect(provider.send('zoned')).to eq('value')
       end
 
-      it 'sets jalied=value' do
+      it 'sets jailed=value' do
         expect(provider).to receive(:zfs).with(:set, 'jailed=value', name)
         provider.send('zoned=', 'value')
       end


### PR DESCRIPTION
Hi,
I noticed this typo in the code.