### PR TITLE
Add relatime parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -123,6 +123,10 @@ The refquota property. Valid values are `<size>`, `none`.
 
 The refreservation property. Valid values are `<size>`, `none`.
 
+##### `relatime`
+
+The relatime property. Valid values are `on`, `off`. Only supported on Linux
+
 ##### `reservation`
 
 The reservation property. Valid values are `<size>`, `none`.

--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -78,7 +78,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   [:aclinherit, :atime, :canmount, :checksum,
    :compression, :copies, :dedup, :devices, :exec, :logbias,
    :mountpoint, :nbmand, :primarycache, :quota, :readonly,
-   :recordsize, :refquota, :refreservation, :reservation,
+   :recordsize, :refquota, :refreservation, :relatime, :reservation,
    :secondarycache, :setuid, :sharenfs, :sharesmb,
    :snapdir, :sync, :version, :volsize, :vscan, :xattr].each do |field|
     define_method(field) do

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -107,7 +107,11 @@ module Puppet
     newproperty(:refreservation) do
       desc 'The refreservation property. Valid values are `<size>`, `none`.'
     end
-
+    
+    newproperty(:relatime) do
+      desc 'The relatime property. Valid values are `on`, `off`. Only supported on Linux' 
+    end
+    
     newproperty(:reservation) do
       desc 'The reservation property. Valid values are `<size>`, `none`.'
     end


### PR DESCRIPTION
Enable setting the relatime parameter for a zfs dataset. Only supported by Linux