### PR TITLE
(PA-5790) Add zfs attribute defaultuserquota

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -67,6 +67,10 @@ The copies property. Valid values are `1`, `2`, `3`.
 
 The dedup property. Valid values are `on`, `off`.
 
+##### `defaultuserquota`
+
+The defaultuserquota property. Valid values are `<size>`, `none`.
+
 ##### `devices`
 
 The devices property. Valid values are `on`, `off`.

--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -57,7 +57,8 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   # aclmode was removed from S11 in build 139 but it may have been added back
   # acltype is for ZFS on Linux, and allows disabling or enabling POSIX ACLs
   # http://webcache.googleusercontent.com/search?q=cache:-p74K0DVsdwJ:developers.slashdot.org/story/11/11/09/2343258/solaris-11-released+&cd=13
-  [:aclmode, :acltype, :shareiscsi, :overlay].each do |field|
+  # defaultuserquota is not supported in zfs filesystem versions older than 6 and will error on Solaris 10 machines
+  [:aclmode, :acltype, :shareiscsi, :overlay, :defaultuserquota].each do |field|
     # The zfs commands use the property value '-' to indicate that the
     # property is not set. We make use of this value to indicate that the
     # property is not set since it is not available. Conversely, if these

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -56,6 +56,16 @@ module Puppet
       desc 'The dedup property. Valid values are `on`, `off`.'
     end
 
+    newproperty(:defaultuserquota) do
+      desc 'The defaultuserquota property. Valid values are `<size>`, `none`.'
+
+      # Solaris 10 uses zfs filesystem version 5 which doesn't support defaultuserquota
+      validate do |_value|
+        raise Puppet::Error _('This property is only supported on zfs filestystem version >= 6') if Facter.value(:kernel) == 'SunOS' && Puppet::Util::Package.versioncmp(Facter.value(:kernelrelease),
+'11') < 0
+      end
+    end
+
     newproperty(:devices) do
       desc 'The devices property. Valid values are `on`, `off`.'
     end

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
 
   describe 'zfs properties' do
     [:aclinherit, :aclmode, :atime, :canmount, :checksum,
-     :compression, :copies, :dedup, :devices, :exec, :logbias,
+     :compression, :copies, :dedup, :defaultuserquota, :devices, :exec, :logbias,
      :mountpoint, :nbmand, :overlay, :primarycache, :quota, :readonly,
      :recordsize, :refquota, :refreservation, :reservation,
      :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb,

--- a/spec/unit/type/zfs_spec.rb
+++ b/spec/unit/type/zfs_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:zfs) do
-  properties = [:ensure, :mountpoint, :compression, :copies, :overlay, :quota, :reservation, :sharenfs, :snapdir, :sync]
+  properties = [:ensure, :mountpoint, :compression, :copies, :overlay, :quota, :defaultuserquota, :reservation, :sharenfs, :snapdir, :sync]
 
   properties.each do |property|
     it "has a #{property} property" do


### PR DESCRIPTION
This commit adds the defaultuserquota attribute. On machines with zfs filesystem version 5 and older, attempting to use this attribute causes an exception/error since defaultuserquota is not a valid attribute on older zfs filesystem versions. This commit adds logic to handle and rescue that exception.

(cherry picked from commit cb3f040d5a13eb3c0eb2e554e107a5441889dd56)