### PR TITLE
(PA-8446) Inherit secrets in nightly tests

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   daily_unit_tests_with_nightly_puppet_gem:
     uses: "puppetlabs/phoenix-github-actions/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml@main"
+    secrets: inherit
 
   notify-via-slack:
     name: Notify workflow conclusion via Slack

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
   gem "puppetlabs_spec_helper", '~> 8.0', require: false
-  gem "puppet-blacksmith", '~> 7.0',      require: false
+  gem "puppet-blacksmith", '~> 8.0',      require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?


### PR DESCRIPTION
## Summary

- Add `secrets: inherit` to the `daily_unit_tests_with_nightly_puppet_gem` workflow job so that secrets are passed through to the reusable workflow.

## Jira

https://perforce.atlassian.net/browse/PA-8446